### PR TITLE
Let the hive UDF handle missing values same way as the model would

### DIFF
--- a/tutorials/hive_udf_template/src/main/java/ai/h2o/hive/udf/ScoreDataUDF.java
+++ b/tutorials/hive_udf_template/src/main/java/ai/h2o/hive/udf/ScoreDataUDF.java
@@ -94,7 +94,7 @@ class ScoreDataUDF extends GenericUDF {
             } else if (o instanceof Short) {
               data[i] = ((Short) o).doubleValue();
             } else if (o == null) {
-              return null;
+              data[i] = Double.NaN;
             } else {
               throw new UDFArgumentException("scoredata(...): Cannot accept type: "
                   + o.getClass().toString() + " for argument # " + i + ".");


### PR DESCRIPTION
This PR changes the evaluate method to return actual predictions instead of a NULL if there is a NULL in the inputs.

According to the documentation, trees handle missing values in the input data by assigning them to the left branch of a split, i.e. they are a "valid" inputs for the tree classifier. The DRF and GBM expects these missing values to be 'Double.NaN's, hence the change. I'm not sure though if this is consistent among all the different model classes.