### PR TITLE
Fixing error when call merge in NYC Tour Example

### DIFF
--- a/h2o-open-tour-2016/nyc/R/Chicago_Airlines_Demo.r
+++ b/h2o-open-tour-2016/nyc/R/Chicago_Airlines_Demo.r
@@ -90,7 +90,7 @@ auc_table1
 
 
 ## Join with weather data by Year, Month, and DayofMonth
-merged_data = h2o.merge(x = flights_hex, y = weather_hex, by.x = 1:3)
+merged_data = h2o.merge(x = flights_hex, y = weather_hex, by = colnames(flights_hex)[1:3])
 
 ## Split frame into test/train split
 split_weather = h2o.splitFrame(data = merged_data,


### PR DESCRIPTION
Fixing error when merging data.

`merged_data = h2o.merge(x = flights_hex, y = weather_hex, by.x = 1:3)`
> Error in h2o.merge(x = flights_hex, y = weather_hex, by.x = 1:3) : 
  `by.x` and `by.y` must be the same length.