### PR TITLE
Fix link to latest-stable R download

### DIFF
--- a/h2o-open-tour-2016/chicago/intro-to-h2o.R
+++ b/h2o-open-tour-2016/chicago/intro-to-h2o.R
@@ -3,7 +3,7 @@
 
 
 # First step is to download & install the h2o R library
-# The latest version is always here: http://www.h2o.ai/download/h2o/r
+# The latest version is available by clicking on the R tab here: http://h2o-release.s3.amazonaws.com/h2o/latest_stable.html
 
 # Load the H2O library and start up the H2O cluster locally on your machine
 library(h2o)


### PR DESCRIPTION
In the intro-to-h2o.R file, changed the link to the latest stable version of R. The www.h2o.ai/download/h2o/r link appears to be hard coded to 3.10.0.0. The latest-stable link will always point to the current released version.