### PR TITLE
Fixes deprecated code for metalearner()

### DIFF
--- a/h2o-world-2017/automl/Python/automl_binary_classification_product_backorders.ipynb
+++ b/h2o-world-2017/automl/Python/automl_binary_classification_product_backorders.ipynb
@@ -398,7 +398,7 @@
     "# Get the \"All Models\" Stacked Ensemble model\n",
     "se = h2o.get_model([mid for mid in model_ids if \"StackedEnsemble_AllModels\" in mid][0])\n",
     "# Get the Stacked Ensemble metalearner model\n",
-    "metalearner = h2o.get_model(se.metalearner()['name'])"
+    "metalearner = se.metalearner()"
    ]
   },
   {


### PR DESCRIPTION
Resolves Issue https://github.com/h2oai/h2o-tutorials/issues/151

Changing the stacked ensemble metalearner() method to the updated version in automl. The code previously in here metalearner = h2o.get_model(se.metalearner()['name']) is deprecated code. Therefore, it's been updated to metalearner = se.metalearner().